### PR TITLE
Add core features plugin scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ wp-content/wp-cache-config.php
 # Theme specific
 
 # Plugin specific
+!wp-content/plugins/matchbox-core-features/
 
 # WP Engine specific (Remove if not hosting with WP Engine)
 .smushit-status

--- a/wp-content/plugins/matchbox-core-features/README.md
+++ b/wp-content/plugins/matchbox-core-features/README.md
@@ -1,0 +1,55 @@
+# Matchbox Core Features
+
+A modern WordPress plugin scaffold for Matchbox WordPress projects.
+
+## Requirements
+
+- PHP 8.2 or higher
+- WordPress 6.6 or higher
+- Node.js 22.0 or higher
+- Composer
+
+## Development
+
+### Available Scripts
+
+- `npm run build` - Build the plugin assets
+- `npm run start` - Start the development server with hot reloading
+- `npm run format` - Format code using WordPress coding standards
+- `npm run lint:css` - Lint CSS files
+- `npm run lint:js` - Lint JavaScript files
+- `npm run plugin-zip` - Create a distributable plugin zip file
+
+### Project Structure
+
+```txt
+matchbox-core-features/
+├── src/                        # PHP source files
+│   └── class-corefeatures.php  # Main plugin class
+├── dist/                       # Built assets
+├── core-features.php           # Plugin bootstrap file
+├── composer.json               # PHP dependencies
+├── package.json                # Node.js dependencies
+└── README.md                   # This file
+```
+
+### Plugin Architecture
+
+The plugin follows modern WordPress development practices:
+
+- PSR-4 autoloading
+- Namespaced PHP classes
+- Modern JavaScript build process
+- WordPress coding standards
+- Composer for dependency management
+
+### Adding Features
+
+1. Create new PHP classes in the `src/` directory.
+2. Add JavaScript files in the `src/` directory.
+3. Register hooks and filters in the `Core_Features` class.
+4. Build assets using `npm run build`.
+
+## Credits
+
+Developed by [Matchbox](https://matchboxdesigngroup.com).

--- a/wp-content/plugins/matchbox-core-features/composer.json
+++ b/wp-content/plugins/matchbox-core-features/composer.json
@@ -1,0 +1,20 @@
+{
+	"name": "matchbox/core-features",
+	"description": "The starting point for all Matchbox WordPress plugins.",
+	"license": "MIT",
+	"type": "wordpress-plugin",
+	"authors": [
+		{
+			"name": "Matchbox"
+		}
+	],
+	"autoload": {
+		"psr-4": {
+			"Matchbox\\CoreFeatures\\": "src/"
+		}
+	},
+	"require": {
+		"php": ">=8.2"
+	},
+	"scripts": {}
+}

--- a/wp-content/plugins/matchbox-core-features/core-features.php
+++ b/wp-content/plugins/matchbox-core-features/core-features.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Plugin Name:       Core Features
+ * Plugin URI:        https://github.com/matchboxdesigngroup/matchbox-wp
+ * Description:       Features and functionality for the {{project_name}} website.
+ * Version:           1.0.0
+ * Requires at least: 6.6
+ * Requires PHP:      8.2
+ * Author:            Matchbox
+ * Author URI:        https://matchboxdesigngroup.com
+ * License:           GPL v2 or later
+ * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
+ * Text Domain:       matchbox-core-features
+ * Domain Path:       /languages
+ * Update URI:        https://github.com/matchboxdesigngroup/matchbox-wp
+ *
+ * @package           matchbox/core-features
+ */
+
+declare(strict_types=1);
+
+namespace Matchbox\CoreFeatures;
+
+// Useful global constants.
+define( 'MATCHBOX_CORE_FEATURES_VERSION', '1.0.0' );
+define( 'MATCHBOX_CORE_FEATURES_URL', plugin_dir_url( __FILE__ ) );
+define( 'MATCHBOX_CORE_FEATURES_PATH', plugin_dir_path( __FILE__ ) );
+define( 'MATCHBOX_CORE_FEATURES_INC', MATCHBOX_CORE_FEATURES_PATH . 'src/' );
+define( 'MATCHBOX_CORE_FEATURES_DIST_URL', MATCHBOX_CORE_FEATURES_URL . 'dist/' );
+define( 'MATCHBOX_CORE_FEATURES_DIST_PATH', MATCHBOX_CORE_FEATURES_PATH . 'dist/' );
+
+// Development environment detection.
+$is_local_env = in_array( wp_get_environment_type(), array( 'local', 'development' ), true );
+$is_local_url = strpos( home_url(), '.test' ) || strpos( home_url(), '.local' );
+$is_local     = $is_local_env || $is_local_url;
+
+if ( $is_local && file_exists( __DIR__ . '/dist/fast-refresh.php' ) ) {
+	require_once __DIR__ . '/dist/fast-refresh.php';
+}
+
+// Bail if Composer autoloader is not found.
+if ( ! file_exists( MATCHBOX_CORE_FEATURES_PATH . 'vendor/autoload.php' ) ) {
+	throw new \Exception(
+		'Vendor autoload file not found. Please run `composer install`.'
+	);
+}
+
+require_once MATCHBOX_CORE_FEATURES_PATH . 'vendor/autoload.php';
+
+// Initialize the plugin.
+$core_features = new Core_Features();
+
+// Activation/Deactivation.
+register_activation_hook( __FILE__, array( $core_features, 'activate' ) );
+register_deactivation_hook( __FILE__, array( $core_features, 'deactivate' ) );
+
+// Bootstrap.
+$core_features->setup();

--- a/wp-content/plugins/matchbox-core-features/package.json
+++ b/wp-content/plugins/matchbox-core-features/package.json
@@ -1,0 +1,19 @@
+{
+	"name": "matchbox-core-features",
+	"version": "1.0.0",
+	"scripts": {
+		"build": "wp-scripts build",
+		"format": "wp-scripts format",
+		"lint:css": "wp-scripts lint-style",
+		"lint:js": "wp-scripts lint-js",
+		"packages-update": "wp-scripts packages-update",
+		"plugin-zip": "wp-scripts plugin-zip",
+		"start": "wp-scripts start"
+	},
+	"engines": {
+		"node": ">=22.0.0"
+	},
+	"devDependencies": {
+		"@wordpress/scripts": "^30.17.0"
+	}
+}

--- a/wp-content/plugins/matchbox-core-features/package.json
+++ b/wp-content/plugins/matchbox-core-features/package.json
@@ -7,7 +7,6 @@
 		"lint:css": "wp-scripts lint-style",
 		"lint:js": "wp-scripts lint-js",
 		"packages-update": "wp-scripts packages-update",
-		"plugin-zip": "wp-scripts plugin-zip",
 		"start": "wp-scripts start"
 	},
 	"engines": {

--- a/wp-content/plugins/matchbox-core-features/src/class-core-features.php
+++ b/wp-content/plugins/matchbox-core-features/src/class-core-features.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Core Features module.
+ *
+ * @package matchbox/core-features
+ */
+
+namespace Matchbox\CoreFeatures;
+
+/**
+ * Core Features module.
+ *
+ * @package matchbox/core-features
+ */
+class Core_Features {
+	/**
+	 * Plugin activation.
+	 *
+	 * @return void
+	 */
+	public function activate(): void {
+		// Activation tasks go here.
+	}
+
+	/**
+	 * Plugin deactivation.
+	 *
+	 * @return void
+	 */
+	public function deactivate(): void {
+		// Deactivation tasks go here.
+	}
+
+	/**
+	 * Plugin setup.
+	 *
+	 * @return void
+	 */
+	public function setup(): void {
+		// Plugin initialization tasks go here.
+	}
+}


### PR DESCRIPTION
## Changes proposed in this pull request

This PR introduces the core features plugin. This plugin scaffolding is intended to contain project-specific functionality. While it should be used in most cases, it can be duplicated if a site's feature is suitable for its own plugin.

Based on an [internal Slack discussion](https://matchbox.slack.com/archives/C06T8LFHE13/p1748471291677159), the team has decided the plugin should not be contained in the `mu-plugins` directory so that it can be easily deactivated during troubleshooting.

By adding the core features plugin to the matchbox-wp template, it will be automatically included in the project's repository.


